### PR TITLE
fix blurhashToImageCssString css

### DIFF
--- a/src/blurhash.ts
+++ b/src/blurhash.ts
@@ -106,5 +106,5 @@ export function blurhashToImageCssString(
     blurhash,
     width,
     height
-  )}") cover`;
+  )}") center/cover`;
 }


### PR DESCRIPTION
The correct CSS is "background: url(...) center/cover" because "background: url(...) cover" is not recognized by browsers.