### PR TITLE
fix: generate valid CSS background shorthand in blurhashToImageCssString

### DIFF
--- a/src/blurhash.ts
+++ b/src/blurhash.ts
@@ -106,5 +106,5 @@ export function blurhashToImageCssString(
     blurhash,
     width,
     height
-  )}") cover`;
+  )}") center/cover no-repeat`;
 }


### PR DESCRIPTION
Fixes #16 

# Background

We are trying to use the new [emdash CMS](https://github.com/emdash-cms/emdash) which uses @ascorbic/unpic-placeholder in it's [EmDashImage.astro](https://github.com/emdash-cms/emdash/blob/emdash%400.1.0/packages/core/src/components/EmDashImage.astro#L155) component and this bug is affecting production build output preventing BlurHash image previews from appearing at all.

# The Bug

In src/css.ts, the blurhashToImageCssString function generates invalid CSS:

```ts
export function blurhashToImageCssString(...): string {
  return `background: url("${blurhashToDataUri(...)}") cover`;
}
```

This produces:
```css
background: url("data:image/bmp;base64,…") cover;
```

Chrome (and all standards-compliant browsers) reject this as an invalid background shorthand. The entire declaration is discarded, so no placeholder is shown at all.

# Why it's invalid

In the CSS background shorthand, `background-size` (cover) must follow `background-position` and be separated by a `/`. The [spec](https://drafts.csswg.org/css-backgrounds/#background) requires:

```
<bg-position> [ / <bg-size> ]?
```

A bare cover after the URL has no valid interpretation — it's not a valid position, repeat, attachment, or origin value, so the whole declaration fails.

# The Fix

Change the return value to include a valid position/size pair and no-repeat:

```ts
return `background: url("${blurhashToDataUri(blurhash, width, height)}") center/cover no-repeat`;
```

This produces:

```css
background: url("data:image/bmp;base64,…") center/cover no-repeat;
```

- `center` — the required background-position
- `/cover` — background-size, now correctly placed after position with / separator
- `no-repeat` — prevents tiling of the tiny placeholder image, which is a sane default since we intend to cover